### PR TITLE
Enable storage add-on

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -11,6 +11,7 @@ jobs:
         channel: '1.18/stable'
         rbac: 'true'
         dns: 'true'
+        storage: 'true'
     - name: Test MicroK8s
       id: microk8s
       run: |

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ This Github Actions enables one to test their applications on multiple Kubernete
 
 **Required**  Since MicroK8s does not enable `dns` by default, user can choose whether they want to enable CoreDNS or not.
 
+### `storage`
+
+**Required** Since MicroK8s does not enable `storage` by default, user can choose whether they want to enable local hostPath storage or not.
+
 ## Example Usage:
 
 Below shows how one can use the Action.
@@ -44,6 +48,7 @@ jobs:
         channel: '1.18/stable'
         rbac: 'true'
         dns: 'true'
+        storage: 'true'
     - name: Test MicroK8s
       id: myactions
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -14,6 +14,10 @@ inputs:
     description: "Enable coredns."
     required: true
     default: "false"
+  storage:
+    description: "Enable storage"
+    required: true
+    default: "false"
 
 runs:
   using: 'node12'

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,12 +35,14 @@ function run() {
         let channel = core.getInput("channel");
         let rbac = core.getInput("rbac");
         let dns = core.getInput("dns");
+        let storage = core.getInput("storage");
         console.log("install microk8s..");
         sh.exec("sudo snap install microk8s --classic --channel=" + channel);
         waitForReadyState();
         prepareUserEnv();
         enableOrDisableRbac(rbac);
         enableOrDisableDns(dns);
+        enableOrDisableStorage(storage);
     });
 }
 function waitForReadyState() {
@@ -81,6 +83,14 @@ function enableOrDisableDns(dns) {
         console.log("Start enabling dns.");
         waitForReadyState();
         sh.exec("sudo microk8s enable dns");
+        waitForReadyState();
+    }
+}
+function enableOrDisableStorage(storage) {
+    if (storage.toLowerCase() === "true") {
+        console.log("Start enabling storage.");
+        waitForReadyState();
+        sh.exec("sudo microk8s enable storage");
         waitForReadyState();
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ async function run() {
   let channel = core.getInput("channel");
   let rbac = core.getInput("rbac");
   let dns = core.getInput("dns");
+  let storage = core.getInput("storage");
 
   console.log("install microk8s..")
   sh.exec("sudo snap install microk8s --classic --channel=" + channel );
@@ -15,6 +16,7 @@ async function run() {
   prepareUserEnv();
   enableOrDisableRbac(rbac);
   enableOrDisableDns(dns);
+  enableOrDisableStorage(storage);
 
 }
 
@@ -58,6 +60,16 @@ function enableOrDisableDns(dns: string) {
     console.log("Start enabling dns.");
     waitForReadyState()
     sh.exec("sudo microk8s enable dns");
+    waitForReadyState()
+  }
+
+}
+
+function enableOrDisableStorage(storage: string) {
+  if (storage.toLowerCase() === "true") {
+    console.log("Start enabling storage.");
+    waitForReadyState()
+    sh.exec("sudo microk8s enable storage");
     waitForReadyState()
   }
 


### PR DESCRIPTION
Hi @balchua , 

I am using this action in one of my workflows and I need to enable the storage add-on, so here is a PR to include it in your action. 

The only thing I am unsure of, is how to test it in the workflow with this updated version, rather than the default "balchua/microk8s-actions@release/v0.1" (since e2e.yaml refers to the latest build). Should we update the e2e.yaml to refer to a build of this action including changes?

Cheers, 
Camille