### PR TITLE
feat: wait for storage to be fully enabled

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -71,6 +71,12 @@ function waitForReadyState() {
         }
     });
 }
+function waitForStorage() {
+    return __awaiter(this, void 0, void 0, function* () {
+        sh.echo('Waiting for storage to be available')
+        sh.exec("sudo microk8s kubectl rollout status deployment/hostpath-provisioner -n kube-system", { silent: true });
+    });
+}
 function prepareUserEnv() {
     // Create microk8s group
     sh.echo("creating microk8s group.");
@@ -97,6 +103,7 @@ function enableOrDisableDns(dns) {
 function enableOrDisableStorage(storage) {
     if (storage.toLowerCase() === "true") {
         enableAddon('storage');
+        waitForStorage();
     }
 }
 function enableAddon(addon) {


### PR DESCRIPTION
This fixes the case where a race condition occurs between the enabling of storage and the usage of that storage in future actions.  Existing waits do not capture delays in storage enabling, so things like `juju bootstrap` will fail when the storage isn't yet available.