### PR TITLE
update to Node 16

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -16,5 +16,5 @@ inputs:
     default: "[]"
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'lib/index.js'


### PR DESCRIPTION
Node 12 is now deprecated, see:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/