### PR TITLE
add troubleshooting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This Github Actions enables one to test their applications on multiple Kubernete
 
 ### `channel`
 
-**Required**  This is the MicroK8s channel to choose.  Example: `latest/stable` or `1.18/stable` or `latest/edge/ha-preview` 
+**Required**  This is the MicroK8s channel to choose.  Example: `latest/stable` or `1.26/stable` 
 
 Strict confinement is also available [see](#strict-confinement)
 
@@ -71,10 +71,10 @@ jobs:
     runs-on: ubuntu-latest
     name: A job to install MicroK8s
     steps:
-    - uses: balchua/microk8s-actions@v0.3.0
+    - uses: balchua/microk8s-actions@v0.3.2
       with:
         channel: '1.26/stable'
-        addons: '["dns", "rbac", "hostpath-storage", "registry", "metrics-server"]'
+        addons: '["dns", "rbac", "hostpath-storage", "registry"]'
     - name: Test MicroK8s
       id: myactions
       run: |
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     name: A job to install MicroK8s with strict confinement
     steps:
-    - uses: balchua/microk8s-actions@v0.3.0
+    - uses: balchua/microk8s-actions@v0.3.2
       with:
         channel: '1.26-strict/stable'
         devMode: 'true'
@@ -144,3 +144,6 @@ The main program is a Typescript, located in [src/index.ts](src/index.ts).  Befo
 $ npm run build
 ```
 
+## Troubleshooting
+
+See [Troubleshooting guide](troubleshooting.md)

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -1,0 +1,18 @@
+# Troubleshooting Guide
+
+## Pushing to local registry
+
+If you are using `docker/setup-buildx-action@v2` and would like to use the internal registry, 
+you need to make sure that the docker network is bound to the host, otherwise you will not be able to push to the local registry.
+
+Example:
+
+``` yaml
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        driver-opts: |
+          network=host
+```
+
+Alternatively, you can use `sudo microk8s ctr image import myimage.tar`.


### PR DESCRIPTION
Closes #14 

This PR adds troubleshooting guide for those using the docker build actions instruction to help push to the local registry.