### PR TITLE
Use HOME env for creating .kube directory.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -87,7 +87,7 @@ function prepareUserEnv(isStrict) {
         executeCommand(false, "sudo usermod -a -G snap_microk8s $USER");
     }
     sh.echo("creating default kubeconfig location.");
-    executeCommand(false, "mkdir -p '/home/runner/.kube/'");
+    executeCommand(false, "mkdir -p $HOME/.kube");
     sh.echo("Generating kubeconfig file to default location.");
     executeCommand(false, "sudo microk8s kubectl config view --raw > $HOME/.kube/config");
     sh.echo("Change default location ownership.");

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ function prepareUserEnv(isStrict: boolean) {
     executeCommand(false, "sudo usermod -a -G snap_microk8s $USER")
   }
   sh.echo("creating default kubeconfig location.");
-  executeCommand(false, "mkdir -p '/home/runner/.kube/'")
+  executeCommand(false, "mkdir -p $HOME/.kube")
   sh.echo("Generating kubeconfig file to default location.");
   executeCommand(false, "sudo microk8s kubectl config view --raw > $HOME/.kube/config")
   sh.echo("Change default location ownership.");


### PR DESCRIPTION
When using self-hosted runners, it is possible to be running under a different user than the default runner user. This fixes a small inconsistency with other executeCommands in the same function, to use the `$HOME` env to create the `.kube` directory.